### PR TITLE
feat: add Kiro steering files

### DIFF
--- a/.kiro/steering/conventions.md
+++ b/.kiro/steering/conventions.md
@@ -1,0 +1,15 @@
+# Project Conventions
+
+## When to Apply
+Always apply when editing any file in this repository.
+
+## Rules
+- This repo contains shared infrastructure code (Lambdas, IAM, Cognito config)
+- All Lambda functions are Python 3.12 with minimal dependencies
+- Use boto3 for AWS SDK calls — no other AWS SDKs
+- Each Lambda has its own directory with handler.py and optional requirements.txt
+- Input validation is mandatory on all Lambda handlers
+- Use environment variables for configuration — never hardcode ARNs or account IDs
+- Keep functions small and single-purpose
+- All responses follow consistent JSON structure: {statusCode, headers, body}
+- CORS headers must be set for all API responses

--- a/.kiro/steering/infrastructure.md
+++ b/.kiro/steering/infrastructure.md
@@ -1,0 +1,16 @@
+# Infrastructure
+
+## When to Apply
+When discussing deploy, CI/CD, or AWS resources.
+
+## Rules
+- Region: us-east-1
+- Shared infrastructure serves all chapters (Brazil, Poland, UK, Chile)
+- Deploy via GitHub Actions — never manual AWS Console changes
+- All resources tagged with `project: golden-jackets` and `chapter` tag
+- Budget alarm at $10/month per chapter — always keep costs minimal
+- Prefer serverless (Lambda, DynamoDB, API Gateway) over always-on resources
+- Lambda timeout: 30s max, memory: 128MB unless justified
+- API Gateway rate limiting: 10 req/s, burst 20
+- DynamoDB on-demand capacity (pay-per-request)
+- Default branch is `main`

--- a/.kiro/steering/security.md
+++ b/.kiro/steering/security.md
@@ -1,0 +1,15 @@
+# Security
+
+## When to Apply
+When editing Lambda functions, IAM policies, or authentication config.
+
+## Rules
+- Least privilege IAM policies — scope to specific resources, never use *
+- Cognito User Pools per chapter — never share pools across chapters
+- Never log sensitive data (emails, tokens, passwords)
+- Sanitize all user input (name, email, URLs) before processing
+- Never expose AWS credentials or account IDs in responses
+- Use OIDC federation for GitHub Actions — no static IAM credentials
+- All secrets in AWS Secrets Manager or environment variables — never in code
+- API Gateway authorizers validate JWT tokens from Cognito
+- CORS restricted to chapter-specific domains only


### PR DESCRIPTION
## Summary\n\nAdds `.kiro/steering/` directory with AI guidance files for the shared infra repo.\n\n### Files added:\n- **conventions.md** — Lambda conventions (Python 3.12, input validation, response structure)\n- **infrastructure.md** — Serverless guidelines, tagging, rate limits\n- **security.md** — IAM least privilege, OIDC, secrets management, CORS\n\nZero impact on infrastructure — files are not deployed or executed.